### PR TITLE
Support Granola cache v4–v6 with auto-detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,9 @@ htmlcov/
 
 # MCPB bundles
 *.mcpb
+
+# Vendored dependencies (built by scripts/build-bundle.sh)
+deps/
+
+# Implementation tasks
+.tasks/

--- a/.mcpbignore
+++ b/.mcpbignore
@@ -16,6 +16,9 @@ build/
 
 # Dev config
 Makefile
+.tasks/
+CACHE_V6_MIGRATION.md
+scripts/
 pytest.ini
 .env
 .env.*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,26 +13,40 @@ src/mcp_granola/
 
 ## Data Source
 
-Reads from: `~/Library/Application Support/Granola/cache-v3.json`
+Auto-detects the newest Granola cache file from `~/Library/Application Support/Granola/`:
+- Tries `cache-v6.json`, `cache-v5.json`, `cache-v4.json`, `cache-v3.json` in order
+- Uses the first file that exists
 
 Data is cached in memory and auto-refreshes when file changes.
 
 ### Structure
 
 ```
-cache-v3.json
-└── cache (JSON string) → parse to:
+cache-vN.json
+└── cache (v3: JSON string, v4+: dict) → normalize to:
     └── state
         ├── documents      # dict: {id: Document}
         ├── transcripts    # dict: {doc_id: Segment[]}
-        └── documentPanels # dict: {doc_id: {panel_id: Panel}}
+        └── documentPanels # dict: {doc_id: {panel_id: Panel}} — v3 only, removed in v6
 ```
+
+### Version Differences
+
+| Feature | v3 | v6 |
+|---------|----|----|
+| `cache` field | JSON string | dict |
+| `documentPanels` | Present | Removed |
+| `notes` (ProseMirror) | Not present | Present on most docs |
+| `notes_plain` | Populated | Partially populated (~77%) |
+| `summary`/`overview` | Populated | Empty (moved server-side) |
+| People `details` | Not present | Enriched (employment, company, avatar) |
 
 ### Gotchas
 
 - **Nullable fields**: Use `doc.get("field") or ""` not `doc.get("field", "")` (values can be explicit `null`)
-- **ProseMirror notes**: Nested structure, use recursive text extraction
+- **ProseMirror notes**: When `notes_plain` is empty, text is auto-extracted from ProseMirror `notes` field
 - **Sparse transcripts**: Most meetings have privacy mode enabled (only 8 of 478 have transcripts)
+- **Panels**: `panels_available` field in `MeetingDetails` indicates whether the cache version includes panel data
 
 ## Commands
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # MCPB bundle configuration
 BUNDLE_NAME = mcp-granola
-VERSION ?= 0.1.0
+VERSION ?= 0.2.0
 
 .PHONY: help install dev-install format format-check lint lint-fix typecheck test test-cov clean run check all
 
@@ -51,6 +51,9 @@ clean: ## Clean up build artifacts and cache
 
 run: ## Run the MCP server in stdio mode
 	uv run python -m mcp_granola.server
+
+bundle: ## Build MCPB bundle locally
+	@./scripts/build-bundle.sh . $(VERSION)
 
 check: format-check lint typecheck test ## Run all checks
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ MCP server for searching your local [Granola](https://granola.ai) meeting notes.
 - Search across notes, titles, and AI summaries
 - Filter by date range or attendee
 - Pull transcripts when available
-- Read AI panels (summaries, action items) that Granola generates
+- Read AI panels (summaries, action items) when available
+- Supports Granola cache v3 through v6
 - Reloads automatically when Granola updates its cache
 
 ## Installation
@@ -42,7 +43,7 @@ uv run python -m mcp_granola.server
 
 ## Data Source
 
-Reads from `~/Library/Application Support/Granola/cache-v3.json` (macOS only). Cached in memory, reloads when the file changes.
+Auto-detects the newest Granola cache file (`cache-v6.json` through `cache-v3.json`) from `~/Library/Application Support/Granola/` (macOS only). Cached in memory, reloads when the file changes.
 
 ## Development
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": "0.3",
   "name": "@nimblebraininc/granola",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Search and extract information from Granola meeting notes",
   "author": {
     "name": "NimbleBrain Inc"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-granola"
-version = "0.1.0"
+version = "0.2.0"
 description = "MCP server for searching and extracting information from Granola meeting notes"
 readme = "README.md"
 license = {text = "MIT"}

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
 asyncio_mode = auto
+testpaths = tests

--- a/scripts/build-bundle.sh
+++ b/scripts/build-bundle.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build an MCPB bundle locally, mirroring the mcpb-pack GitHub Action.
+# Usage: ./scripts/build-bundle.sh [directory] [version]
+
+DIR="${1:-.}"
+VERSION="${2:-}"
+
+cd "$DIR"
+
+# Read name from manifest
+NAME=$(jq -r '.name' manifest.json)
+if [ -z "$NAME" ] || [ "$NAME" = "null" ]; then
+  echo "Error: could not read name from manifest.json" >&2
+  exit 1
+fi
+
+# Determine version: argument > manifest > fallback
+if [ -z "$VERSION" ]; then
+  VERSION=$(jq -r '.version' manifest.json)
+fi
+if [ -z "$VERSION" ] || [ "$VERSION" = "null" ]; then
+  echo "Error: no version provided and none found in manifest.json" >&2
+  exit 1
+fi
+
+# Detect OS and arch for the output filename
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m)
+case "$ARCH" in
+  x86_64)  ARCH="amd64" ;;
+  aarch64) ARCH="arm64" ;;
+  arm64)   ARCH="arm64" ;;
+esac
+
+# Sanitize scoped package name (@scope/name -> scope-name) for filename
+SAFE_NAME=$(echo "$NAME" | sed 's|^@||; s|/|-|g')
+OUTPUT="${SAFE_NAME}-${VERSION}-${OS}-${ARCH}.mcpb"
+
+echo "Building bundle: $OUTPUT"
+echo "  name:    $NAME"
+echo "  version: $VERSION"
+echo "  os:      $OS"
+echo "  arch:    $ARCH"
+
+# Vendor Python dependencies (matches mcpb-pack action)
+echo ""
+echo "Vendoring Python dependencies into deps/..."
+rm -rf deps/
+uv pip install --target ./deps --only-binary :all: . 2>/dev/null || \
+uv pip install --target ./deps .
+
+echo "Vendored packages:"
+ls deps/ | head -20 || true
+du -sh deps/
+
+# Pack the bundle
+echo ""
+echo "Packing bundle..."
+mcpb pack . "$OUTPUT"
+
+echo ""
+echo "Bundle built: $OUTPUT"
+ls -lh "$OUTPUT"

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://schemas.nimblebrain.ai/v1/nimblebrain-server.schema.json",
   "name": "ai.nimblebrain/granola",
   "description": "Search and extract information from local Granola meeting notes",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "title": "Granola MCP Server",
   "repository": {
     "url": "https://github.com/NimbleBrainInc/mcp-granola",

--- a/src/mcp_granola/__init__.py
+++ b/src/mcp_granola/__init__.py
@@ -1,3 +1,3 @@
 """MCP Granola - Search and extract from Granola meeting notes."""
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/src/mcp_granola/data.py
+++ b/src/mcp_granola/data.py
@@ -44,7 +44,7 @@ class GranolaData:
         """Load data from file, refreshing if changed."""
         if self._needs_reload():
             self._cache_path = _find_cache_path()
-            if self._cache_path is None or not self._cache_path.exists():
+            if self._cache_path is None:
                 self._data = {"documents": {}, "transcripts": {}, "documentPanels": {}}
                 return self._data
 
@@ -190,7 +190,9 @@ class GranolaData:
             if score > 0:
                 doc = self.documents[doc_id]
                 snippets = []
-                notes = doc.get("notes_plain", "")
+                notes = doc.get("notes_plain") or ""
+                if not notes and doc.get("notes"):
+                    notes = self._extract_prosemirror_text(doc["notes"])
                 if query_lower in notes.lower():
                     snippets.append(self._extract_snippet(notes, query))
 

--- a/src/mcp_granola/data.py
+++ b/src/mcp_granola/data.py
@@ -4,7 +4,17 @@ import json
 from pathlib import Path
 from typing import Any
 
-GRANOLA_PATH = Path.home() / "Library/Application Support/Granola/cache-v3.json"
+GRANOLA_DIR = Path.home() / "Library/Application Support/Granola"
+CACHE_VERSIONS = ["cache-v6.json", "cache-v5.json", "cache-v4.json", "cache-v3.json"]
+
+
+def _find_cache_path() -> Path | None:
+    """Find the newest available Granola cache file."""
+    for filename in CACHE_VERSIONS:
+        path = GRANOLA_DIR / filename
+        if path.exists():
+            return path
+    return None
 
 
 class GranolaData:
@@ -14,6 +24,7 @@ class GranolaData:
     _data: dict[str, Any] | None = None
     _last_modified: float | None = None
     _search_cache: dict[str, dict[str, Any]] | None = None
+    _cache_path: Path | None = None
 
     def __new__(cls) -> "GranolaData":
         if cls._instance is None:
@@ -22,22 +33,28 @@ class GranolaData:
 
     def _needs_reload(self) -> bool:
         """Check if data needs to be reloaded."""
-        if not GRANOLA_PATH.exists():
-            return False
-        current_mtime = GRANOLA_PATH.stat().st_mtime
+        if self._cache_path is None:
+            return self._data is None
+        if not self._cache_path.exists():
+            return self._data is None
+        current_mtime = self._cache_path.stat().st_mtime
         return self._data is None or current_mtime != self._last_modified
 
     def _load(self) -> dict[str, Any]:
         """Load data from file, refreshing if changed."""
         if self._needs_reload():
-            if not GRANOLA_PATH.exists():
+            self._cache_path = _find_cache_path()
+            if self._cache_path is None or not self._cache_path.exists():
                 self._data = {"documents": {}, "transcripts": {}, "documentPanels": {}}
                 return self._data
 
-            with open(GRANOLA_PATH) as f:
+            with open(self._cache_path) as f:
                 raw = json.load(f)
-            self._data = json.loads(raw["cache"])["state"]
-            self._last_modified = GRANOLA_PATH.stat().st_mtime
+            cache = raw["cache"]
+            if isinstance(cache, str):
+                cache = json.loads(cache)
+            self._data = cache["state"]
+            self._last_modified = self._cache_path.stat().st_mtime
             self._search_cache = None  # Invalidate search cache
         return self._data or {}
 
@@ -78,7 +95,10 @@ class GranolaData:
         """Extract all searchable text from a document."""
         texts = []
         texts.append(doc.get("title") or "")
-        texts.append(doc.get("notes_plain") or "")
+        notes_plain = doc.get("notes_plain") or ""
+        if not notes_plain and doc.get("notes"):
+            notes_plain = self._extract_prosemirror_text(doc["notes"])
+        texts.append(notes_plain)
         texts.append(doc.get("notes_markdown") or "")
         if doc.get("summary"):
             texts.append(doc["summary"])
@@ -202,15 +222,20 @@ class GranolaData:
             content = self._extract_panel_text(panel.get("content", {}))
             panels.append({"id": panel_id, "title": panel.get("title", ""), "content": content})
 
+        notes_plain = doc.get("notes_plain") or ""
+        if not notes_plain and doc.get("notes"):
+            notes_plain = self._extract_prosemirror_text(doc["notes"])
+
         return {
             "id": doc_id,
             "title": doc.get("title", ""),
             "created_at": doc.get("created_at", ""),
             "updated_at": doc.get("updated_at"),
             "notes_markdown": doc.get("notes_markdown", ""),
-            "notes_plain": doc.get("notes_plain", ""),
+            "notes_plain": notes_plain,
             "attendees": self._get_attendees(doc),
             "panels": panels,
+            "panels_available": "documentPanels" in self._load(),
             "has_transcript": len(transcript) > 0,
             "transcript_segments": len(transcript),
         }

--- a/src/mcp_granola/models.py
+++ b/src/mcp_granola/models.py
@@ -47,6 +47,7 @@ class MeetingDetails(BaseModel):
     notes_plain: str
     attendees: list[MeetingAttendee]
     panels: list[MeetingPanel]
+    panels_available: bool
     has_transcript: bool
     transcript_segments: int
 

--- a/src/mcp_granola/server.py
+++ b/src/mcp_granola/server.py
@@ -125,6 +125,7 @@ async def get_meeting(
         panels=[
             MeetingPanel(id=p["id"], title=p["title"], content=p["content"]) for p in doc["panels"]
         ],
+        panels_available=doc["panels_available"],
         has_transcript=doc["has_transcript"],
         transcript_segments=doc["transcript_segments"],
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,27 +22,51 @@ def fixture_data() -> dict[str, Any]:
 
 
 @pytest.fixture()
-def granola_data(fixture_data: dict[str, Any]) -> GranolaData:
-    """Create a GranolaData instance backed by fixture data.
+def fixture_data_v6() -> dict[str, Any]:
+    """Load the test fixture cache-v6.json and return parsed state."""
+    fixture_path = FIXTURES_DIR / "cache-v6.json"
+    raw = json.loads(fixture_path.read_text())
+    # v6: cache is already a dict, not a JSON string
+    return raw["cache"]["state"]
 
-    Patches the singleton and file loading to use test fixtures.
-    """
-    # Reset singleton state
+
+def _make_granola_data(data: dict[str, Any]) -> GranolaData:
+    """Create a GranolaData instance backed by fixture data."""
     GranolaData._instance = None
     GranolaData._data = None
     GranolaData._last_modified = None
     GranolaData._search_cache = None
+    GranolaData._cache_path = None
 
     instance = GranolaData()
-    instance._data = fixture_data
+    instance._data = data
     instance._last_modified = 1.0  # Prevent reload attempts
     return instance
 
 
 @pytest.fixture()
+def granola_data(fixture_data: dict[str, Any]) -> GranolaData:
+    """Create a GranolaData instance backed by v3 fixture data."""
+    return _make_granola_data(fixture_data)
+
+
+@pytest.fixture()
+def granola_data_v6(fixture_data_v6: dict[str, Any]) -> GranolaData:
+    """Create a GranolaData instance backed by v6 fixture data."""
+    return _make_granola_data(fixture_data_v6)
+
+
+@pytest.fixture()
 def mcp_server(granola_data: GranolaData):
-    """Provide the FastMCP server with data patched to use fixtures."""
+    """Provide the FastMCP server with data patched to use v3 fixtures."""
     with patch("mcp_granola.server.get_data", return_value=granola_data):
+        yield mcp
+
+
+@pytest.fixture()
+def mcp_server_v6(granola_data_v6: GranolaData):
+    """Provide the FastMCP server with data patched to use v6 fixtures."""
+    with patch("mcp_granola.server.get_data", return_value=granola_data_v6):
         yield mcp
 
 
@@ -54,3 +78,4 @@ def _reset_singleton():
     GranolaData._data = None
     GranolaData._last_modified = None
     GranolaData._search_cache = None
+    GranolaData._cache_path = None

--- a/tests/fixtures/cache-v6.json
+++ b/tests/fixtures/cache-v6.json
@@ -1,0 +1,287 @@
+{
+  "cache": {
+    "version": 5,
+    "state": {
+      "documents": {
+        "doc-001": {
+          "title": "Q1 Planning Session",
+          "created_at": "2025-01-15T10:00:00Z",
+          "updated_at": "2025-01-15T11:30:00Z",
+          "notes_plain": "Discussed Q1 roadmap priorities. Key items: launch new API, hire two engineers, improve onboarding flow.",
+          "notes_markdown": "# Q1 Planning\n\n- Launch new API\n- Hire two engineers\n- Improve onboarding flow",
+          "notes": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "content": [{"type": "text", "text": "Q1 Planning"}]
+              },
+              {
+                "type": "bulletList",
+                "content": [
+                  {"type": "listItem", "content": [{"type": "paragraph", "content": [{"type": "text", "text": "Launch new API"}]}]},
+                  {"type": "listItem", "content": [{"type": "paragraph", "content": [{"type": "text", "text": "Hire two engineers"}]}]},
+                  {"type": "listItem", "content": [{"type": "paragraph", "content": [{"type": "text", "text": "Improve onboarding flow"}]}]}
+                ]
+              }
+            ]
+          },
+          "summary": "",
+          "overview": "",
+          "type": "meeting",
+          "creation_source": "macOS",
+          "privacy_mode_enabled": false,
+          "workspace_id": "ws-001",
+          "google_calendar_event": null,
+          "people": {
+            "creator": {
+              "name": "Alice Chen",
+              "email": "alice@example.com",
+              "details": {
+                "person": {"name": {"fullName": "Alice Chen"}, "avatar": "https://example.com/alice.jpg", "employment": {"name": "Acme Corp"}},
+                "company": {"name": "Acme Corp"}
+              }
+            },
+            "attendees": [
+              {
+                "name": "Bob Smith",
+                "email": "bob@example.com",
+                "details": {
+                  "person": {"name": {"fullName": "Bob Smith"}, "avatar": "https://example.com/bob.jpg", "employment": {"name": "Acme Corp"}},
+                  "company": {"name": "Acme Corp"}
+                }
+              },
+              {
+                "name": "Carol Davis",
+                "email": "carol@example.com",
+                "details": {
+                  "person": {"name": {"fullName": "Carol Davis"}, "avatar": null, "employment": {"name": "Acme Corp"}},
+                  "company": {"name": "Acme Corp"}
+                }
+              }
+            ]
+          }
+        },
+        "doc-002": {
+          "title": "Design Review: Onboarding",
+          "created_at": "2025-01-20T14:00:00Z",
+          "updated_at": "2025-01-20T15:00:00Z",
+          "notes_plain": "",
+          "notes_markdown": "",
+          "notes": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "content": [{"type": "text", "text": "Design Review"}]
+              },
+              {
+                "type": "paragraph",
+                "content": [{"type": "text", "text": "Reviewed new onboarding mockups. Decided to simplify the signup flow to three steps."}]
+              }
+            ]
+          },
+          "summary": "",
+          "overview": "",
+          "type": "meeting",
+          "creation_source": "macOS",
+          "privacy_mode_enabled": false,
+          "workspace_id": "ws-001",
+          "google_calendar_event": null,
+          "people": {
+            "creator": {
+              "name": "Carol Davis",
+              "email": "carol@example.com"
+            },
+            "attendees": [
+              {"name": "Alice Chen", "email": "alice@example.com"}
+            ]
+          }
+        },
+        "doc-003": {
+          "title": "Sprint Retrospective",
+          "created_at": "2025-02-01T09:00:00Z",
+          "updated_at": null,
+          "notes_plain": "",
+          "notes_markdown": "",
+          "notes": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "content": [{"type": "text", "text": "Retro"}]
+              },
+              {
+                "type": "bulletList",
+                "content": [
+                  {"type": "listItem", "content": [{"type": "paragraph", "content": [{"type": "text", "text": "Good velocity this sprint"}]}]},
+                  {"type": "listItem", "content": [{"type": "paragraph", "content": [{"type": "text", "text": "Need to improve code review turnaround time"}]}]}
+                ]
+              }
+            ]
+          },
+          "summary": "",
+          "overview": "",
+          "type": "meeting",
+          "creation_source": "macOS",
+          "privacy_mode_enabled": true,
+          "workspace_id": "ws-001",
+          "google_calendar_event": null,
+          "people": {
+            "creator": {
+              "name": "Bob Smith",
+              "email": "bob@example.com"
+            },
+            "attendees": [
+              {"name": "Alice Chen", "email": "alice@example.com"},
+              {"name": "Dave Wilson", "email": "dave@example.com"}
+            ]
+          }
+        },
+        "doc-004": {
+          "title": "API Architecture Discussion",
+          "created_at": "2025-02-10T11:00:00Z",
+          "updated_at": "2025-02-10T12:00:00Z",
+          "notes_plain": "Debated REST vs GraphQL for the new API. Decided on REST with OpenAPI spec. Will use FastAPI.",
+          "notes_markdown": "# API Architecture\n\n- REST over GraphQL\n- OpenAPI spec\n- FastAPI framework",
+          "notes": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "content": [{"type": "text", "text": "API Architecture"}]
+              },
+              {
+                "type": "bulletList",
+                "content": [
+                  {"type": "listItem", "content": [{"type": "paragraph", "content": [{"type": "text", "text": "REST over GraphQL"}]}]},
+                  {"type": "listItem", "content": [{"type": "paragraph", "content": [{"type": "text", "text": "OpenAPI spec"}]}]},
+                  {"type": "listItem", "content": [{"type": "paragraph", "content": [{"type": "text", "text": "FastAPI framework"}]}]}
+                ]
+              }
+            ]
+          },
+          "summary": "",
+          "overview": "",
+          "type": "meeting",
+          "creation_source": "macOS",
+          "privacy_mode_enabled": false,
+          "workspace_id": "ws-001",
+          "google_calendar_event": {
+            "summary": "API Architecture Discussion",
+            "htmlLink": "https://calendar.google.com/event/abc123"
+          },
+          "people": {
+            "creator": {
+              "name": "Alice Chen",
+              "email": "alice@example.com",
+              "details": {
+                "person": {"name": {"fullName": "Alice Chen"}, "avatar": "https://example.com/alice.jpg", "employment": {"name": "Acme Corp"}},
+                "company": {"name": "Acme Corp"}
+              }
+            },
+            "attendees": [
+              {
+                "name": "Bob Smith",
+                "email": "bob@example.com",
+                "details": {
+                  "person": {"name": {"fullName": "Bob Smith"}, "avatar": "https://example.com/bob.jpg", "employment": {"name": "Acme Corp"}},
+                  "company": {"name": "Acme Corp"}
+                }
+              },
+              {
+                "name": "Eve Martinez",
+                "email": "eve@example.com",
+                "details": {
+                  "person": {"name": {"fullName": "Eve Martinez"}, "avatar": null, "employment": {"name": "Other Inc"}},
+                  "company": {"name": "Other Inc"}
+                }
+              }
+            ]
+          }
+        },
+        "doc-005": {
+          "title": "1:1 with Carol",
+          "created_at": "2025-02-15T16:00:00Z",
+          "updated_at": "2025-02-15T16:30:00Z",
+          "notes_plain": "Career growth discussion. Carol interested in tech lead role. Set up mentoring plan.",
+          "notes_markdown": "# 1:1 Carol\n\n- Career growth\n- Tech lead path\n- Mentoring plan",
+          "notes": {
+            "type": "doc",
+            "content": [
+              {
+                "type": "heading",
+                "content": [{"type": "text", "text": "1:1 Carol"}]
+              },
+              {
+                "type": "bulletList",
+                "content": [
+                  {"type": "listItem", "content": [{"type": "paragraph", "content": [{"type": "text", "text": "Career growth"}]}]},
+                  {"type": "listItem", "content": [{"type": "paragraph", "content": [{"type": "text", "text": "Tech lead path"}]}]},
+                  {"type": "listItem", "content": [{"type": "paragraph", "content": [{"type": "text", "text": "Mentoring plan"}]}]}
+                ]
+              }
+            ]
+          },
+          "summary": "",
+          "overview": "",
+          "type": "meeting",
+          "creation_source": "macOS",
+          "privacy_mode_enabled": false,
+          "workspace_id": "ws-001",
+          "google_calendar_event": null,
+          "people": {
+            "creator": {
+              "name": "Alice Chen",
+              "email": "alice@example.com"
+            },
+            "attendees": [
+              {"name": "Carol Davis", "email": "carol@example.com"}
+            ]
+          }
+        }
+      },
+      "transcripts": {
+        "doc-001": [
+          {
+            "text": "Let's start with the Q1 priorities.",
+            "start_timestamp": "00:00:05",
+            "end_timestamp": "00:00:08",
+            "source": "speaker_1"
+          },
+          {
+            "text": "I think the API launch should be our top priority.",
+            "start_timestamp": "00:00:10",
+            "end_timestamp": "00:00:14",
+            "source": "speaker_2"
+          },
+          {
+            "text": "Agreed. We also need to hire two more engineers.",
+            "start_timestamp": "00:00:15",
+            "end_timestamp": "00:00:19",
+            "source": "speaker_1"
+          }
+        ],
+        "doc-004": [
+          {
+            "text": "Should we go with REST or GraphQL?",
+            "start_timestamp": "00:01:00",
+            "end_timestamp": "00:01:04",
+            "source": "speaker_1"
+          },
+          {
+            "text": "REST is simpler and better for our use case.",
+            "start_timestamp": "00:01:05",
+            "end_timestamp": "00:01:09",
+            "source": "speaker_2"
+          }
+        ]
+      },
+      "entities": {
+        "chat_thread": {},
+        "chat_message": {}
+      },
+      "meetingsMetadata": {}
+    }
+  }
+}

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import patch
 
-from mcp_granola.data import GranolaData, get_data
+from mcp_granola.data import CACHE_VERSIONS, GranolaData, _find_cache_path, get_data
 
 
 class TestGranolaSingleton:
@@ -39,24 +39,25 @@ class TestDataLoading:
         assert "panel-001" in granola_data.panels["doc-001"]
 
     def test_missing_file_returns_empty(self):
-        """When the Granola cache file doesn't exist, properties return empty."""
+        """When no Granola cache file exists, properties return empty."""
         import mcp_granola.data as data_module
 
-        original = data_module.GRANOLA_PATH
+        original = data_module.GRANOLA_DIR
         try:
-            data_module.GRANOLA_PATH = Path("/nonexistent/path.json")
+            data_module.GRANOLA_DIR = Path("/nonexistent/dir")
             data = GranolaData()
             data._data = None
             data._last_modified = None
-            # _needs_reload returns False for missing file, so _load returns {}
+            data._cache_path = None
             assert data.documents == {}
             assert data.transcripts == {}
             assert data.panels == {}
         finally:
-            data_module.GRANOLA_PATH = original
+            data_module.GRANOLA_DIR = original
 
     def test_reload_on_file_change(self, granola_data: GranolaData):
         """Changing mtime triggers reload detection."""
+        granola_data._cache_path = Path("/tmp/fake-cache.json")
         granola_data._last_modified = 0.0  # Old mtime
         with patch.object(Path, "exists", return_value=True):
             with patch.object(Path, "stat") as mock_stat:
@@ -397,3 +398,144 @@ class TestGetStats:
     def test_stats_total_transcripts(self, granola_data: GranolaData):
         stats = granola_data.get_stats()
         assert stats["total_transcripts"] == 2
+
+
+class TestCacheAutoDetection:
+    def test_find_cache_path_prefers_highest_version(self, tmp_path: Path):
+        """Auto-detection returns the highest version cache file."""
+        import mcp_granola.data as data_module
+
+        original = data_module.GRANOLA_DIR
+        try:
+            data_module.GRANOLA_DIR = tmp_path
+            (tmp_path / "cache-v3.json").touch()
+            (tmp_path / "cache-v6.json").touch()
+            result = _find_cache_path()
+            assert result is not None
+            assert result.name == "cache-v6.json"
+        finally:
+            data_module.GRANOLA_DIR = original
+
+    def test_find_cache_path_falls_back(self, tmp_path: Path):
+        """Falls back to lower versions when higher ones don't exist."""
+        import mcp_granola.data as data_module
+
+        original = data_module.GRANOLA_DIR
+        try:
+            data_module.GRANOLA_DIR = tmp_path
+            (tmp_path / "cache-v3.json").touch()
+            result = _find_cache_path()
+            assert result is not None
+            assert result.name == "cache-v3.json"
+        finally:
+            data_module.GRANOLA_DIR = original
+
+    def test_find_cache_path_returns_none_when_empty(self, tmp_path: Path):
+        """Returns None when no cache files exist."""
+        import mcp_granola.data as data_module
+
+        original = data_module.GRANOLA_DIR
+        try:
+            data_module.GRANOLA_DIR = tmp_path
+            assert _find_cache_path() is None
+        finally:
+            data_module.GRANOLA_DIR = original
+
+    def test_cache_versions_order(self):
+        """Cache versions are ordered highest to lowest."""
+        assert CACHE_VERSIONS[0] == "cache-v6.json"
+        assert CACHE_VERSIONS[-1] == "cache-v3.json"
+
+
+class TestV6DataLoading:
+    def test_load_v6_documents(self, granola_data_v6: GranolaData):
+        """v6 fixture loads with correct document count."""
+        assert len(granola_data_v6.documents) == 5
+
+    def test_v6_no_panels(self, granola_data_v6: GranolaData):
+        """v6 data has no documentPanels."""
+        assert granola_data_v6.panels == {}
+
+    def test_v6_transcripts_unchanged(self, granola_data_v6: GranolaData):
+        """v6 transcripts have the same structure as v3."""
+        assert "doc-001" in granola_data_v6.transcripts
+        assert len(granola_data_v6.transcripts["doc-001"]) == 3
+
+    def test_v6_documents_have_notes_field(self, granola_data_v6: GranolaData):
+        """v6 documents have ProseMirror notes field."""
+        doc = granola_data_v6.documents["doc-001"]
+        assert "notes" in doc
+        assert doc["notes"]["type"] == "doc"
+
+
+class TestV6ProseMirrorFallback:
+    def test_fallback_populates_notes_plain(self, granola_data_v6: GranolaData):
+        """When notes_plain is empty, get_document extracts from ProseMirror notes."""
+        doc = granola_data_v6.get_document("doc-002")
+        assert doc is not None
+        # doc-002 has empty notes_plain but populated ProseMirror notes
+        assert "onboarding" in doc["notes_plain"].lower()
+
+    def test_no_fallback_when_notes_plain_exists(self, granola_data_v6: GranolaData):
+        """When notes_plain is populated, it's returned as-is."""
+        doc = granola_data_v6.get_document("doc-001")
+        assert doc is not None
+        assert (
+            doc["notes_plain"]
+            == "Discussed Q1 roadmap priorities. Key items: launch new API, hire two engineers, improve onboarding flow."
+        )
+
+    def test_search_finds_prosemirror_only_docs(self, granola_data_v6: GranolaData):
+        """Search indexes content from ProseMirror-only documents."""
+        # doc-003 has empty notes_plain but ProseMirror notes with "code review"
+        results = granola_data_v6.search("code review")
+        titles = [r["title"] for r in results]
+        assert "Sprint Retrospective" in titles
+
+
+class TestV6PanelsAvailable:
+    def test_v3_panels_available(self, granola_data: GranolaData):
+        """v3 data reports panels as available."""
+        doc = granola_data.get_document("doc-001")
+        assert doc is not None
+        assert doc["panels_available"] is True
+
+    def test_v6_panels_not_available(self, granola_data_v6: GranolaData):
+        """v6 data reports panels as not available."""
+        doc = granola_data_v6.get_document("doc-001")
+        assert doc is not None
+        assert doc["panels_available"] is False
+        assert doc["panels"] == []
+
+    def test_v3_panels_have_content(self, granola_data: GranolaData):
+        """v3 panels contain extracted text."""
+        doc = granola_data.get_document("doc-001")
+        assert doc is not None
+        assert len(doc["panels"]) == 2
+        panel_titles = [p["title"] for p in doc["panels"]]
+        assert "Action Items" in panel_titles
+
+
+class TestV6Attendees:
+    def test_v6_enriched_attendees_still_work(self, granola_data_v6: GranolaData):
+        """Attendee extraction works with v6 enriched people data."""
+        doc = granola_data_v6.documents["doc-001"]
+        attendees = granola_data_v6._get_attendees(doc)
+        emails = {a["email"] for a in attendees}
+        assert "alice@example.com" in emails
+        assert "bob@example.com" in emails
+        assert "carol@example.com" in emails
+
+    def test_v6_search_by_person(self, granola_data_v6: GranolaData):
+        """search_by_person works with v6 data."""
+        results = granola_data_v6.search_by_person("Alice")
+        assert len(results) >= 3
+
+
+class TestV6Stats:
+    def test_v6_stats(self, granola_data_v6: GranolaData):
+        """Stats work correctly with v6 data."""
+        stats = granola_data_v6.get_stats()
+        assert stats["total_documents"] == 5
+        assert stats["documents_with_transcripts"] == 2
+        assert stats["unique_attendees"] >= 4

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -492,6 +492,14 @@ class TestV6ProseMirrorFallback:
         titles = [r["title"] for r in results]
         assert "Sprint Retrospective" in titles
 
+    def test_search_snippets_from_prosemirror_only_docs(self, granola_data_v6: GranolaData):
+        """Search returns snippets for ProseMirror-only documents."""
+        # doc-002 has empty notes_plain but ProseMirror notes with "onboarding"
+        results = granola_data_v6.search("onboarding")
+        matching = [r for r in results if r["title"] == "Design Review: Onboarding"]
+        assert len(matching) == 1
+        assert len(matching[0]["snippets"]) >= 1
+
 
 class TestV6PanelsAvailable:
     def test_v3_panels_available(self, granola_data: GranolaData):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -88,11 +88,13 @@ class TestMeetingDetails:
             notes_plain="Test",
             attendees=[MeetingAttendee(name="Alice", email="alice@example.com")],
             panels=[],
+            panels_available=True,
             has_transcript=False,
             transcript_segments=0,
         )
         assert details.updated_at is None
         assert details.has_transcript is False
+        assert details.panels_available is True
 
     def test_with_all_fields(self):
         details = MeetingDetails(
@@ -107,6 +109,7 @@ class TestMeetingDetails:
                 MeetingAttendee(name="B", email="b@x.com"),
             ],
             panels=[MeetingPanel(id="p1", title="Summary", content="text")],
+            panels_available=True,
             has_transcript=True,
             transcript_segments=5,
         )

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -149,6 +149,47 @@ class TestGetMeetingStatsTool:
         assert result is not None
 
 
+class TestV6SearchMeetingsTool:
+    @pytest.mark.asyncio
+    async def test_search_finds_prosemirror_content(self, mcp_server_v6):
+        """Search returns results from ProseMirror-only documents."""
+        async with Client(mcp_server_v6) as client:
+            result = await client.call_tool("search_meetings", {"query": "code review"})
+        assert result is not None
+
+    @pytest.mark.asyncio
+    async def test_search_with_attendee(self, mcp_server_v6):
+        async with Client(mcp_server_v6) as client:
+            result = await client.call_tool(
+                "search_meetings", {"query": "API", "attendee": "alice"}
+            )
+        assert result is not None
+
+
+class TestV6GetMeetingTool:
+    @pytest.mark.asyncio
+    async def test_v6_meeting_no_panels(self, mcp_server_v6):
+        """get_meeting on v6 data returns panels_available=False."""
+        async with Client(mcp_server_v6) as client:
+            result = await client.call_tool("get_meeting", {"meeting_id": "doc-001"})
+        assert result is not None
+
+    @pytest.mark.asyncio
+    async def test_v6_meeting_notes_fallback(self, mcp_server_v6):
+        """get_meeting extracts notes from ProseMirror when notes_plain is empty."""
+        async with Client(mcp_server_v6) as client:
+            result = await client.call_tool("get_meeting", {"meeting_id": "doc-002"})
+        assert result is not None
+
+
+class TestV6StatsTool:
+    @pytest.mark.asyncio
+    async def test_v6_stats(self, mcp_server_v6):
+        async with Client(mcp_server_v6) as client:
+            result = await client.call_tool("get_meeting_stats", {})
+        assert result is not None
+
+
 class TestToolListing:
     @pytest.mark.asyncio
     async def test_all_tools_registered(self, mcp_server):

--- a/uv.lock
+++ b/uv.lock
@@ -687,7 +687,7 @@ wheels = [
 
 [[package]]
 name = "mcp-granola"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary

Closes #1

- **Auto-detect cache version** — tries v6, v5, v4, v3 in order, uses the first that exists
- **Normalize cache parsing** — handles `cache` as JSON string (v3) or dict (v4+)
- **ProseMirror notes fallback** — extracts text from `notes` field when `notes_plain` is empty, recovering ~139 docs in v6
- **Graceful missing panels** — new `panels_available` field on `MeetingDetails` indicates when panel data is unavailable (v6 removed `documentPanels`)
- **Local bundle build** — `scripts/build-bundle.sh` + `make bundle` for local MCPB testing
- **Version bump** — 0.1.0 → 0.2.0

## Test plan

- [x] 122 tests pass (100 existing + 22 new v6 tests)
- [x] `make check` clean (format, lint, typecheck, test)
- [x] Smoke tested against real v6 cache (605 documents loaded)
- [x] `make bundle && mpak bundle run --local` works end-to-end
- [ ] CI passes