### PR TITLE
Add skill resource and fix search cache reentrancy bug

### DIFF
--- a/src/mcp_granola/SKILL.md
+++ b/src/mcp_granola/SKILL.md
@@ -1,0 +1,52 @@
+# Granola MCP Server — Skill Guide
+
+## Tools
+
+| Tool | Use when... |
+|------|-------------|
+| `list_meetings` | You need to browse recent meetings or paginate through history |
+| `search_meetings` | You have a keyword or phrase to search across all meeting notes |
+| `search_by_person` | You want all meetings involving a specific person (by name or email) |
+| `get_meeting` | You have a `meeting_id` and need the full notes, attendees, and panels |
+| `get_transcript` | You need the raw transcript segments for a specific meeting |
+| `get_meeting_stats` | You need an overview of how much data is available |
+
+## Parameter Reference
+
+All tools that accept meeting identifiers use `meeting_id` (not `doc_id`, `id`, or `document_id`). The `meeting_id` value comes from the `id` field in search results and meeting lists.
+
+## Context Reuse
+
+- Use `id` from `list_meetings` or `search_meetings` results as the `meeting_id` parameter for `get_meeting` and `get_transcript`
+- Use `has_transcript` from meeting lists to decide whether calling `get_transcript` will return data
+- Use `attendee_count` from meeting lists to gauge meeting size before fetching full details
+
+## Workflows
+
+### 1. Summarize a Meeting with a Specific Person
+1. `search_by_person` with their name to find meetings
+2. Pick the relevant meeting by title/date
+3. `get_meeting` with `meeting_id` to get notes and panels
+4. If notes are sparse and `has_transcript` is true: `get_transcript` with `meeting_id`
+
+### 2. Find and Review a Topic
+1. `search_meetings` with keywords (e.g., "pricing", "roadmap")
+2. Review snippets in results to find the right meeting
+3. `get_meeting` with `meeting_id` for full context
+
+### 3. Browse Recent Activity
+1. `list_meetings` with default sort (newest first)
+2. Filter by date range or attendee if needed
+3. `get_meeting` on items of interest
+
+### 4. Get Transcript for Deep Review
+1. Find the meeting via search or list
+2. Check `has_transcript` — most meetings have privacy mode enabled and won't have transcripts
+3. `get_transcript` with `meeting_id` and `format="timestamped"` for timing info
+
+## Tips
+
+- **Transcript availability is rare**: Most Granola meetings use privacy mode. Check `has_transcript` before attempting `get_transcript`.
+- **`get_meeting` with `include_transcript=True`**: Appends the transcript to the notes in a single call — useful when you want everything at once without a separate `get_transcript` call.
+- **Date filters**: Use `YYYY-MM-DD` format for `date_from` and `date_to` parameters.
+- **Attendee filter**: Works on both name and email — partial matches are supported.

--- a/src/mcp_granola/SKILL.md
+++ b/src/mcp_granola/SKILL.md
@@ -39,7 +39,11 @@ All tools that accept meeting identifiers use `meeting_id` (not `doc_id`, `id`, 
 2. Filter by date range or attendee if needed
 3. `get_meeting` on items of interest
 
-### 4. Get Transcript for Deep Review
+### 4. Check Data Availability
+1. `get_meeting_stats` to see how many meetings are stored, date range, and transcript coverage
+2. Use the stats to set expectations — e.g., if `documents_with_transcripts` is low, transcript-based workflows will have limited results
+
+### 5. Get Transcript for Deep Review
 1. Find the meeting via search or list
 2. Check `has_transcript` — most meetings have privacy mode enabled and won't have transcripts
 3. `get_transcript` with `meeting_id` and `format="timestamped"` for timing info

--- a/src/mcp_granola/data.py
+++ b/src/mcp_granola/data.py
@@ -78,17 +78,21 @@ class GranolaData:
         if self._search_cache is not None:
             return self._search_cache
 
-        self._search_cache = {}
-        for doc_id, doc in self.documents.items():
+        # Snapshot documents first — accessing self.documents triggers _load(),
+        # which can set self._search_cache = None mid-build if the file changed.
+        docs = self.documents
+        cache: dict[str, dict[str, Any]] = {}
+        for doc_id, doc in docs.items():
             searchable = self._get_searchable_text(doc)
             title = doc.get("title") or ""
             created_at = doc.get("created_at") or ""
-            self._search_cache[doc_id] = {
+            cache[doc_id] = {
                 "text": searchable.lower(),
                 "title": title,
                 "date": created_at[:10] if created_at else "",
                 "attendees": self._get_attendees(doc),
             }
+        self._search_cache = cache
         return self._search_cache
 
     def _get_searchable_text(self, doc: dict[str, Any]) -> str:

--- a/src/mcp_granola/server.py
+++ b/src/mcp_granola/server.py
@@ -1,5 +1,7 @@
 """Granola MCP Server - Search and extract from meeting notes."""
 
+from importlib.resources import files
+
 from fastmcp import Context, FastMCP
 from starlette.requests import Request
 from starlette.responses import JSONResponse
@@ -19,7 +21,21 @@ from .models import (
 )
 
 # Create MCP server
-mcp = FastMCP("Granola")
+mcp = FastMCP(
+    "Granola",
+    instructions=(
+        "Before using tools, read the skill://granola/usage resource "
+        "for tool selection guidance and parameter reference."
+    ),
+)
+
+SKILL_CONTENT = files("mcp_granola").joinpath("SKILL.md").read_text()
+
+
+@mcp.resource("skill://granola/usage")
+def granola_skill() -> str:
+    """How to effectively use this server's tools."""
+    return SKILL_CONTENT
 
 
 # Health endpoint for HTTP transport

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -400,6 +400,38 @@ class TestGetStats:
         assert stats["total_transcripts"] == 2
 
 
+class TestSearchCacheReentrancy:
+    """Regression test: _build_search_cache must not break if _load() invalidates
+    the cache mid-build (e.g. when the Granola cache file changes on disk)."""
+
+    def test_search_cache_survives_mid_build_reload(self, granola_data: GranolaData):
+        """Simulate file change during _build_search_cache iteration.
+
+        Before the fix, accessing self.documents inside the loop triggered
+        _load(), which set self._search_cache = None while _build_search_cache
+        was writing to it — causing 'NoneType' object does not support item assignment.
+        """
+        original_load = granola_data._load
+
+        call_count = 0
+
+        def load_that_invalidates_cache() -> dict:
+            nonlocal call_count
+            call_count += 1
+            # On the second call (triggered by self.documents inside the loop),
+            # simulate what _load does when the file has changed: invalidate the cache.
+            if call_count == 2:
+                granola_data._search_cache = None
+            return original_load()
+
+        granola_data._search_cache = None  # Force rebuild
+        granola_data._load = load_that_invalidates_cache
+
+        # Before the fix this raised: TypeError: 'NoneType' object does not support item assignment
+        results = granola_data.search_by_person("Alice")
+        assert len(results) >= 1
+
+
 class TestCacheAutoDetection:
     def test_find_cache_path_prefers_highest_version(self, tmp_path: Path):
         """Auto-detection returns the highest version cache file."""

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -190,6 +190,32 @@ class TestV6StatsTool:
         assert result is not None
 
 
+class TestSkillResource:
+    @pytest.mark.asyncio
+    async def test_skill_resource_listed(self, mcp_server):
+        """The skill://granola/usage resource is discoverable."""
+        async with Client(mcp_server) as client:
+            resources = await client.list_resources()
+        uris = {str(r.uri) for r in resources}
+        assert "skill://granola/usage" in uris
+
+    @pytest.mark.asyncio
+    async def test_skill_resource_readable(self, mcp_server):
+        """The skill resource returns non-empty markdown content."""
+        async with Client(mcp_server) as client:
+            result = await client.read_resource("skill://granola/usage")
+        content = result[0].text if hasattr(result[0], "text") else str(result[0])
+        assert "## Tools" in content
+        assert "meeting_id" in content
+
+    @pytest.mark.asyncio
+    async def test_server_instructions_reference_skill(self, mcp_server):
+        """Server instructions point LLMs to the skill resource."""
+        async with Client(mcp_server) as client:
+            init = await client.initialize()
+        assert "skill://granola/usage" in init.instructions
+
+
 class TestToolListing:
     @pytest.mark.asyncio
     async def test_all_tools_registered(self, mcp_server):


### PR DESCRIPTION
## Summary
- **Skill resource**: Adds `SKILL.md` served as `skill://granola/usage` MCP resource. Teaches LLMs correct parameter names (e.g. `meeting_id` not `doc_id`), tool selection patterns, and multi-step workflows. Follows the same pattern as ipinfo, hunter, and other servers.
- **Cache reentrancy fix**: Fixes a bug where `_build_search_cache` could crash with `'NoneType' object does not support item assignment` when the Granola cache file changes on disk mid-iteration. The `self.documents` property access triggered `_load()`, which set `self._search_cache = None` while the method was writing to it.
- **Regression test**: Validates the reentrancy fix by simulating a mid-build cache invalidation.

## Test plan
- [x] All 124 tests pass (`uv run pytest tests/ -v`)
- [x] Skill resource loads correctly at runtime
- [x] Regression test reproduces the original crash when the fix is reverted