### PR TITLE
Fix NoneType crashes caused by explicit null fields in cache-v6

### DIFF
--- a/src/mcp_granola/data.py
+++ b/src/mcp_granola/data.py
@@ -113,7 +113,7 @@ class GranolaData:
     def _get_attendees(self, doc: dict[str, Any]) -> list[dict[str, str]]:
         """Extract attendees from a document."""
         attendees = []
-        people = doc.get("people", {})
+        people = doc.get("people") or {}
 
         # Creator
         creator = people.get("creator", {})

--- a/src/mcp_granola/data.py
+++ b/src/mcp_granola/data.py
@@ -234,10 +234,10 @@ class GranolaData:
 
         return {
             "id": doc_id,
-            "title": doc.get("title", ""),
-            "created_at": doc.get("created_at", ""),
+            "title": doc.get("title") or "",
+            "created_at": doc.get("created_at") or "",
             "updated_at": doc.get("updated_at"),
-            "notes_markdown": doc.get("notes_markdown", ""),
+            "notes_markdown": doc.get("notes_markdown") or "",
             "notes_plain": notes_plain,
             "attendees": self._get_attendees(doc),
             "panels": panels,


### PR DESCRIPTION
## Problem

Two `AttributeError: 'NoneType'` crashes affect users on Granola cache v6, making all tools fail.

Python's `dict.get(key, default)` only uses the default when the key is **missing** — not when the value is an explicit `null`. In cache-v6, several documents have fields set to `null` rather than being absent, which slips through this guard and causes downstream failures.

## Affected fields (observed in cache-v6 with 164 documents)

| Field | Null count | Impact |
|-------|-----------|--------|
| `notes_markdown` | 89/164 | `MeetingDetails` Pydantic validation fails (`str` field receives `None`) |
| `people` | 1/164 | `_build_search_cache` crashes on startup — **all tools fail** |

## Fix

Switch from `dict.get(key, default)` to `(dict.get(key) or default)` in two places:

```python
# _get_attendees — people can be explicit null
people = doc.get("people") or {}  # was: doc.get("people", {})

# get_document — notes_markdown (and defensively title/created_at) can be explicit null
"title": doc.get("title") or "",
"created_at": doc.get("created_at") or "",
"notes_markdown": doc.get("notes_markdown") or "",
```

## Testing

Verified against a live cache-v6 with 164 documents (89 null `notes_markdown`, 1 null `people`). All tools (`list_documents`, `search`, `get_document`, `get_stats`) pass cleanly after the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)