### PR TITLE
Add date filtering and intent-based meeting tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,3 +77,5 @@ mpak bundle run @nimblebraininc/granola
 | `search_by_person` | Find meetings with specific person |
 | `get_transcript` | Get raw transcript segments |
 | `get_meeting_stats` | Data statistics |
+| `summarize_meetings` | Summarize meetings over a time period (with notes + attendees) |
+| `extract_action_items` | Extract action items/TODOs from meetings |

--- a/src/mcp_granola/SKILL.md
+++ b/src/mcp_granola/SKILL.md
@@ -10,10 +10,27 @@
 | `get_meeting` | You have a `meeting_id` and need the full notes, attendees, and panels |
 | `get_transcript` | You need the raw transcript segments for a specific meeting |
 | `get_meeting_stats` | You need an overview of how much data is available |
+| `summarize_meetings` | You need a recap of meetings over a time period (returns notes + attendees) |
+| `extract_action_items` | You need TODOs, next steps, or action items from one or more meetings |
 
 ## Parameter Reference
 
 All tools that accept meeting identifiers use `meeting_id` (not `doc_id`, `id`, or `document_id`). The `meeting_id` value comes from the `id` field in search results and meeting lists.
+
+## Date Parameters
+
+Tools that accept time ranges (`summarize_meetings`, `extract_action_items`, `list_meetings`, `search_meetings`, `search_by_person`) support two ways to specify dates:
+
+- **`date_from` / `date_to`** (YYYY-MM-DD): Explicit date range. Use when the user asks for a calendar-aligned period. Compute the actual YYYY-MM-DD dates yourself.
+- **`days`** (integer, `summarize_meetings` and `extract_action_items` only): Shortcut for "last N days from today". Use when the user says "recent" or "last N days".
+
+If neither is provided, `summarize_meetings` and `extract_action_items` default to the last 7 days.
+
+**Examples of how to translate user requests:**
+- "What happened last week?" → compute Monday–Sunday dates, use `date_from`/`date_to`
+- "Summarize my last 30 days" → use `days=30`
+- "Action items from January" → use `date_from="2026-01-01"`, `date_to="2026-01-31"`
+- "What did I discuss with Carol recently?" → use `days=14` with `person="Carol"`
 
 ## Context Reuse
 
@@ -24,7 +41,7 @@ All tools that accept meeting identifiers use `meeting_id` (not `doc_id`, `id`, 
 ## Workflows
 
 ### 1. Summarize a Meeting with a Specific Person
-1. `search_by_person` with their name to find meetings
+1. `search_by_person` with their name to find meetings — use `date_from`/`date_to` to scope to the relevant time period
 2. Pick the relevant meeting by title/date
 3. `get_meeting` with `meeting_id` to get notes and panels
 4. If notes are sparse and `has_transcript` is true: `get_transcript` with `meeting_id`
@@ -48,9 +65,20 @@ All tools that accept meeting identifiers use `meeting_id` (not `doc_id`, `id`, 
 2. Check `has_transcript` — most meetings have privacy mode enabled and won't have transcripts
 3. `get_transcript` with `meeting_id` and `format="timestamped"` for timing info
 
+### 6. Summarize Meetings Over a Period
+1. `summarize_meetings` with `days=7` or explicit `date_from`/`date_to`
+2. Optionally filter by `person` to scope to a specific colleague
+3. Review the returned notes and attendees to build the summary
+
+### 7. Extract Action Items
+1. For a single meeting: `extract_action_items` with `meeting_id`
+2. For a time range: `extract_action_items` with `days=7` or `date_from`/`date_to`
+3. Optionally filter by `person` to see only items from meetings with that person
+4. Group the returned items by meeting for organized presentation
+
 ## Tips
 
 - **Transcript availability is rare**: Most Granola meetings use privacy mode. Check `has_transcript` before attempting `get_transcript`.
 - **`get_meeting` with `include_transcript=True`**: Appends the transcript to the notes in a single call — useful when you want everything at once without a separate `get_transcript` call.
-- **Date filters**: Use `YYYY-MM-DD` format for `date_from` and `date_to` parameters.
+- **Date filters**: Always scope queries to the relevant time period to avoid returning stale results from months or years ago.
 - **Attendee filter**: Works on both name and email — partial matches are supported.

--- a/src/mcp_granola/data.py
+++ b/src/mcp_granola/data.py
@@ -1,8 +1,9 @@
 """Granola data loader with caching and search functionality."""
 
 import json
+import re
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 GRANOLA_DIR = Path.home() / "Library/Application Support/Granola"
 CACHE_VERSIONS = ["cache-v6.json", "cache-v5.json", "cache-v4.json", "cache-v3.json"]
@@ -323,13 +324,25 @@ class GranolaData:
         total = len(items)
         return total, items[offset : offset + limit]
 
-    def search_by_person(self, person: str, limit: int = 20) -> list[dict[str, Any]]:
+    def search_by_person(
+        self,
+        person: str,
+        limit: int = 20,
+        date_from: str | None = None,
+        date_to: str | None = None,
+    ) -> list[dict[str, Any]]:
         """Find meetings with a specific person."""
         cache = self._build_search_cache()
         person_lower = person.lower()
         results = []
 
         for doc_id, cached in cache.items():
+            # Date filtering
+            if date_from and cached["date"] < date_from:
+                continue
+            if date_to and cached["date"] > date_to:
+                continue
+
             for att in cached["attendees"]:
                 if person_lower in att["name"].lower() or person_lower in att["email"].lower():
                     transcript = self.transcripts.get(doc_id, [])
@@ -373,6 +386,147 @@ class GranolaData:
             "total_segments": len(segments),
             "format": format,
         }
+
+    def get_meeting_summaries(
+        self,
+        date_from: str,
+        date_to: str,
+        person: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """Get meetings with notes in a date range, optionally filtered by person."""
+        cache = self._build_search_cache()
+        results = []
+
+        for doc_id, cached in cache.items():
+            if cached["date"] < date_from or cached["date"] > date_to:
+                continue
+
+            if person:
+                person_lower = person.lower()
+                if not any(
+                    person_lower in a["name"].lower() or person_lower in a["email"].lower()
+                    for a in cached["attendees"]
+                ):
+                    continue
+
+            doc = self.get_document(doc_id)
+            if not doc:
+                continue
+
+            results.append(
+                {
+                    "id": doc_id,
+                    "title": doc["title"],
+                    "date": cached["date"],
+                    "notes_plain": doc["notes_plain"],
+                    "attendees": doc["attendees"],
+                }
+            )
+
+        results.sort(key=lambda x: x["date"], reverse=True)
+        return results
+
+    def extract_action_items(
+        self,
+        meeting_id: str | None = None,
+        date_from: str | None = None,
+        date_to: str | None = None,
+        person: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """Extract action items from meeting notes and panels.
+
+        Can target a single meeting by ID, or multiple meetings by date range.
+        """
+        # Determine which meetings to process
+        if meeting_id:
+            doc = self.get_document(meeting_id)
+            if not doc:
+                return []
+            cache = self._build_search_cache()
+            cached = cache.get(meeting_id)
+            meetings = [
+                {
+                    "id": meeting_id,
+                    "title": doc["title"],
+                    "date": cached["date"] if cached else "",
+                    "doc": doc,
+                }
+            ]
+        elif date_from and date_to:
+            summaries = self.get_meeting_summaries(
+                date_from=date_from, date_to=date_to, person=person
+            )
+            meetings = []
+            for s in summaries:
+                doc = self.get_document(s["id"])
+                if doc:
+                    meetings.append(
+                        {
+                            "id": s["id"],
+                            "title": s["title"],
+                            "date": s["date"],
+                            "doc": doc,
+                        }
+                    )
+        else:
+            return []
+
+        # Extract action items from each meeting
+        items: list[dict[str, Any]] = []
+        for m in meetings:
+            doc = cast(dict[str, Any], m["doc"])
+
+            # Extract from panels (highest quality — Granola's AI panels)
+            panels: list[dict[str, Any]] = doc.get("panels", [])
+            for panel in panels:
+                if "action" in panel.get("title", "").lower():
+                    for line in str(panel.get("content", "")).split("\n"):
+                        line = line.strip().lstrip("- ").strip()
+                        if line:
+                            items.append(
+                                {
+                                    "action": line,
+                                    "meeting_id": m["id"],
+                                    "meeting_title": m["title"],
+                                    "meeting_date": m["date"],
+                                    "source": "panel",
+                                }
+                            )
+
+            # Extract from notes — look for bullet points and action-oriented lines
+            notes: str = doc.get("notes_plain", "") or ""
+            for line in notes.split("\n"):
+                line = line.strip()
+                if not line:
+                    continue
+                # Match bullet points (-, *, [ ], [x])
+                bullet_match = re.match(r"^[-*]\s+(.+)", line)
+                checkbox_match = re.match(r"^\[[ x]]\s+(.+)", line, re.IGNORECASE)
+                if bullet_match:
+                    text = bullet_match.group(1).strip()
+                    # Skip if already captured from panels
+                    if not any(text in item["action"] or item["action"] in text for item in items):
+                        items.append(
+                            {
+                                "action": text,
+                                "meeting_id": m["id"],
+                                "meeting_title": m["title"],
+                                "meeting_date": m["date"],
+                                "source": "notes",
+                            }
+                        )
+                elif checkbox_match:
+                    items.append(
+                        {
+                            "action": checkbox_match.group(1).strip(),
+                            "meeting_id": m["id"],
+                            "meeting_title": m["title"],
+                            "meeting_date": m["date"],
+                            "source": "notes",
+                        }
+                    )
+
+        return items
 
     def get_stats(self) -> dict[str, Any]:
         """Get statistics about the data."""

--- a/src/mcp_granola/models.py
+++ b/src/mcp_granola/models.py
@@ -99,3 +99,39 @@ class DataStats(BaseModel):
     date_range_start: str
     date_range_end: str
     unique_attendees: int
+
+
+class MeetingSummary(BaseModel):
+    """A meeting with notes for summarization."""
+
+    id: str
+    title: str
+    date: str
+    notes_plain: str
+    attendees: list[MeetingAttendee]
+
+
+class SummarizeMeetingsResponse(BaseModel):
+    """Response from summarize_meetings tool."""
+
+    total: int
+    date_from: str
+    date_to: str
+    meetings: list[MeetingSummary]
+
+
+class ActionItem(BaseModel):
+    """A single extracted action item."""
+
+    action: str
+    meeting_id: str
+    meeting_title: str
+    meeting_date: str
+    source: str
+
+
+class ActionItemsResponse(BaseModel):
+    """Response from extract_action_items tool."""
+
+    total: int
+    action_items: list[ActionItem]

--- a/src/mcp_granola/server.py
+++ b/src/mcp_granola/server.py
@@ -1,5 +1,6 @@
 """Granola MCP Server - Search and extract from meeting notes."""
 
+from datetime import date, timedelta
 from importlib.resources import files
 
 from fastmcp import Context, FastMCP
@@ -8,14 +9,18 @@ from starlette.responses import JSONResponse
 
 from .data import get_data
 from .models import (
+    ActionItem,
+    ActionItemsResponse,
     DataStats,
     ListMeetingsResponse,
     MeetingAttendee,
     MeetingDetails,
     MeetingListItem,
     MeetingPanel,
+    MeetingSummary,
     SearchResponse,
     SearchResult,
+    SummarizeMeetingsResponse,
     TranscriptResponse,
     TranscriptSegment,
 )
@@ -30,6 +35,12 @@ mcp = FastMCP(
 )
 
 SKILL_CONTENT = files("mcp_granola").joinpath("SKILL.md").read_text()
+
+
+def _resolve_days(days: int) -> tuple[str, str]:
+    """Convert 'last N days' into (date_from, date_to) ISO date strings."""
+    today = date.today()
+    return (today - timedelta(days=days)).isoformat(), today.isoformat()
 
 
 @mcp.resource("skill://granola/usage")
@@ -205,6 +216,8 @@ async def list_meetings(
 async def search_by_person(
     person: str,
     limit: int = 20,
+    date_from: str | None = None,
+    date_to: str | None = None,
     ctx: Context | None = None,
 ) -> ListMeetingsResponse:
     """Find all meetings involving a specific person.
@@ -212,6 +225,8 @@ async def search_by_person(
     Args:
         person: Person's name or email address
         limit: Maximum results (default: 20)
+        date_from: Filter by start date (YYYY-MM-DD)
+        date_to: Filter by end date (YYYY-MM-DD)
         ctx: MCP context
 
     Returns:
@@ -221,7 +236,7 @@ async def search_by_person(
         await ctx.info(f"Searching meetings with: {person}")
 
     data = get_data()
-    items = data.search_by_person(person=person, limit=limit)
+    items = data.search_by_person(person=person, limit=limit, date_from=date_from, date_to=date_to)
 
     return ListMeetingsResponse(
         total=len(items),
@@ -282,6 +297,129 @@ async def get_transcript(
         ],
         total_segments=result["total_segments"],
         format=result["format"],
+    )
+
+
+@mcp.tool()
+async def summarize_meetings(
+    date_from: str | None = None,
+    date_to: str | None = None,
+    days: int | None = None,
+    person: str | None = None,
+    ctx: Context | None = None,
+) -> SummarizeMeetingsResponse:
+    """Get meeting summaries with notes for a time period.
+
+    Use this when asked to summarize, recap, or review meetings over a period.
+    Provide either date_from/date_to (YYYY-MM-DD) or days (last N days).
+
+    Args:
+        date_from: Start date (YYYY-MM-DD)
+        date_to: End date (YYYY-MM-DD)
+        days: Convenience shortcut: last N days from today
+        person: Filter by attendee name or email
+        ctx: MCP context
+
+    Returns:
+        Meetings with their notes and attendees
+    """
+    if date_from or date_to:
+        if not date_from:
+            date_from = "2000-01-01"
+        if not date_to:
+            date_to = date.today().isoformat()
+    elif days is not None:
+        date_from, date_to = _resolve_days(days)
+    else:
+        date_from, date_to = _resolve_days(7)
+
+    if ctx:
+        await ctx.info(f"Summarizing meetings from {date_from} to {date_to}")
+
+    data = get_data()
+    results = data.get_meeting_summaries(date_from=date_from, date_to=date_to, person=person)
+
+    return SummarizeMeetingsResponse(
+        total=len(results),
+        date_from=date_from,
+        date_to=date_to,
+        meetings=[
+            MeetingSummary(
+                id=r["id"],
+                title=r["title"],
+                date=r["date"],
+                notes_plain=r["notes_plain"],
+                attendees=[
+                    MeetingAttendee(name=a["name"], email=a["email"]) for a in r["attendees"]
+                ],
+            )
+            for r in results
+        ],
+    )
+
+
+@mcp.tool()
+async def extract_action_items(
+    meeting_id: str | None = None,
+    date_from: str | None = None,
+    date_to: str | None = None,
+    days: int | None = None,
+    person: str | None = None,
+    ctx: Context | None = None,
+) -> ActionItemsResponse:
+    """Extract action items from meeting notes.
+
+    Use this when asked for action items, TODOs, or next steps.
+    Can target a single meeting by ID, or scan multiple meetings by date range.
+
+    Args:
+        meeting_id: Specific meeting ID to extract from (takes precedence)
+        date_from: Start date (YYYY-MM-DD) for scanning multiple meetings
+        date_to: End date (YYYY-MM-DD) for scanning multiple meetings
+        days: Convenience shortcut: last N days from today
+        person: Filter by attendee name or email (only with date range)
+        ctx: MCP context
+
+    Returns:
+        Extracted action items with source meeting context
+    """
+    if not meeting_id:
+        if date_from or date_to:
+            if not date_from:
+                date_from = "2000-01-01"
+            if not date_to:
+                date_to = date.today().isoformat()
+        elif days is not None:
+            date_from, date_to = _resolve_days(days)
+        else:
+            date_from, date_to = _resolve_days(7)
+
+    if ctx:
+        if meeting_id:
+            await ctx.info(f"Extracting action items from meeting: {meeting_id}")
+        else:
+            await ctx.info(f"Extracting action items from {date_from} to {date_to}")
+
+    data = get_data()
+    items = data.extract_action_items(
+        meeting_id=meeting_id,
+        date_from=date_from,
+        date_to=date_to,
+        person=person,
+    )
+
+    return ActionItemsResponse(
+        total=len(items),
+        action_items=[
+            ActionItem(
+                action=item["action"],
+                meeting_id=item["meeting_id"],
+                meeting_title=item["meeting_title"],
+                meeting_date=item["meeting_date"],
+                source=item["source"],
+            )
+            for item in items
+        ],
     )
 
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -352,6 +352,37 @@ class TestSearchByPerson:
         results = granola_data.search_by_person("Alice", limit=1)
         assert len(results) <= 1
 
+    def test_date_from_filter(self, granola_data: GranolaData):
+        """search_by_person with date_from excludes older meetings."""
+        # Alice has meetings in Jan and Feb 2025
+        results = granola_data.search_by_person("Alice", date_from="2025-02-01")
+        for r in results:
+            assert r["date"] >= "2025-02-01"
+        # Should have fewer results than without date filter
+        all_results = granola_data.search_by_person("Alice")
+        assert len(results) < len(all_results)
+
+    def test_date_to_filter(self, granola_data: GranolaData):
+        """search_by_person with date_to excludes newer meetings."""
+        results = granola_data.search_by_person("Alice", date_to="2025-01-31")
+        for r in results:
+            assert r["date"] <= "2025-01-31"
+        all_results = granola_data.search_by_person("Alice")
+        assert len(results) < len(all_results)
+
+    def test_date_range_filter(self, granola_data: GranolaData):
+        """search_by_person with both date_from and date_to scopes correctly."""
+        results = granola_data.search_by_person(
+            "Alice", date_from="2025-01-15", date_to="2025-01-20"
+        )
+        for r in results:
+            assert "2025-01-15" <= r["date"] <= "2025-01-20"
+
+    def test_date_filter_no_results(self, granola_data: GranolaData):
+        """Date range with no meetings returns empty."""
+        results = granola_data.search_by_person("Alice", date_from="2026-01-01")
+        assert results == []
+
 
 class TestGetTranscript:
     def test_with_transcript(self, granola_data: GranolaData):
@@ -615,3 +646,131 @@ class TestV6Stats:
         assert stats["total_documents"] == 5
         assert stats["documents_with_transcripts"] == 2
         assert stats["unique_attendees"] >= 4
+
+
+class TestGetMeetingSummaries:
+    """Tests for the get_meeting_summaries method that returns meetings
+    with their notes for a given duration."""
+
+    def test_returns_meetings_in_range(self, granola_data: GranolaData):
+        """Meetings within the duration are returned."""
+        # Fixture has meetings from 2025-01-15 to 2025-02-15
+        results = granola_data.get_meeting_summaries(date_from="2025-02-01", date_to="2025-02-28")
+        assert len(results) >= 1
+        for r in results:
+            assert r["date"] >= "2025-02-01"
+            assert r["date"] <= "2025-02-28"
+
+    def test_excludes_meetings_outside_range(self, granola_data: GranolaData):
+        """Meetings outside the duration are excluded."""
+        results = granola_data.get_meeting_summaries(date_from="2025-02-01", date_to="2025-02-28")
+        for r in results:
+            assert r["date"] >= "2025-02-01"
+        # Jan meetings should not appear
+        jan_results = [r for r in results if r["date"].startswith("2025-01")]
+        assert len(jan_results) == 0
+
+    def test_includes_notes_and_attendees(self, granola_data: GranolaData):
+        """Each result includes notes and attendee info."""
+        results = granola_data.get_meeting_summaries(date_from="2025-01-01", date_to="2025-12-31")
+        assert len(results) == 5
+        for r in results:
+            assert "id" in r
+            assert "title" in r
+            assert "date" in r
+            assert "notes_plain" in r
+            assert "attendees" in r
+            assert isinstance(r["attendees"], list)
+
+    def test_sorted_newest_first(self, granola_data: GranolaData):
+        """Results are sorted by date descending."""
+        results = granola_data.get_meeting_summaries(date_from="2025-01-01", date_to="2025-12-31")
+        dates = [r["date"] for r in results]
+        assert dates == sorted(dates, reverse=True)
+
+    def test_with_person_filter(self, granola_data: GranolaData):
+        """Can filter by person within the date range."""
+        results = granola_data.get_meeting_summaries(
+            date_from="2025-01-01", date_to="2025-12-31", person="Carol"
+        )
+        assert len(results) >= 1
+        for r in results:
+            attendee_names = [a["name"].lower() for a in r["attendees"]]
+            attendee_emails = [a["email"].lower() for a in r["attendees"]]
+            assert any("carol" in n for n in attendee_names) or any(
+                "carol" in e for e in attendee_emails
+            )
+
+    def test_empty_range(self, granola_data: GranolaData):
+        """Date range with no meetings returns empty list."""
+        results = granola_data.get_meeting_summaries(date_from="2026-01-01", date_to="2026-12-31")
+        assert results == []
+
+    def test_notes_plain_populated(self, granola_data: GranolaData):
+        """notes_plain is populated (not empty) for meetings that have notes."""
+        results = granola_data.get_meeting_summaries(date_from="2025-01-15", date_to="2025-01-15")
+        assert len(results) == 1
+        assert "Q1 roadmap" in results[0]["notes_plain"]
+
+
+class TestExtractActionItems:
+    """Tests for the extract_action_items method that parses action items
+    from meeting notes."""
+
+    def test_single_meeting_by_id(self, granola_data: GranolaData):
+        """Extracts action items from a specific meeting."""
+        # doc-001 has panels with "Launch API by end of Q1" and "Post job listings"
+        # and notes with "launch new API, hire two engineers, improve onboarding flow"
+        items = granola_data.extract_action_items(meeting_id="doc-001")
+        assert len(items) >= 1
+        # Each item should have the meeting context
+        for item in items:
+            assert "action" in item
+            assert "meeting_id" in item
+            assert "meeting_title" in item
+            assert "meeting_date" in item
+            assert item["meeting_id"] == "doc-001"
+
+    def test_action_items_from_panels(self, granola_data: GranolaData):
+        """Action items are extracted from panel content (e.g., 'Action Items' panel)."""
+        items = granola_data.extract_action_items(meeting_id="doc-001")
+        action_texts = [item["action"] for item in items]
+        # The "Action Items" panel has these bullet points
+        assert any("Launch API" in a for a in action_texts)
+        assert any("job listings" in a or "engineers" in a for a in action_texts)
+
+    def test_action_items_from_date_range(self, granola_data: GranolaData):
+        """Extracts action items across meetings in a date range."""
+        items = granola_data.extract_action_items(date_from="2025-01-01", date_to="2025-02-28")
+        assert len(items) >= 1
+        # Items from multiple meetings
+        meeting_ids = {item["meeting_id"] for item in items}
+        assert len(meeting_ids) >= 1
+
+    def test_nonexistent_meeting_returns_empty(self, granola_data: GranolaData):
+        """Non-existent meeting ID returns empty list."""
+        items = granola_data.extract_action_items(meeting_id="nonexistent")
+        assert items == []
+
+    def test_meeting_without_action_items(self, granola_data: GranolaData):
+        """Meeting with no action-oriented content returns empty list."""
+        # doc-002 "Design Review" - has notes but no explicit action items panel
+        # May or may not extract items depending on the heuristic
+        items = granola_data.extract_action_items(meeting_id="doc-002")
+        # At minimum, should not crash
+        assert isinstance(items, list)
+
+    def test_action_items_with_person_filter(self, granola_data: GranolaData):
+        """Can filter action items by person across a date range."""
+        items = granola_data.extract_action_items(
+            date_from="2025-01-01", date_to="2025-12-31", person="Carol"
+        )
+        # Should only have items from meetings where Carol attended
+        for item in items:
+            doc = granola_data.get_document(item["meeting_id"])
+            assert doc is not None
+            attendee_names = [a["name"].lower() for a in doc["attendees"]]
+            attendee_emails = [a["email"].lower() for a in doc["attendees"]]
+            assert any("carol" in n for n in attendee_names) or any(
+                "carol" in e for e in attendee_emails
+            )

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -114,3 +114,119 @@ class TestE2EPaginationConsistency:
                 offset += 2
 
             assert len(all_ids) == total
+
+
+class TestE2ESearchByPersonDateFilter:
+    """Verify search_by_person date filtering works through the MCP layer."""
+
+    @pytest.mark.asyncio
+    async def test_date_from_filters_old_meetings(self, mcp_server):
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "search_by_person",
+                {"person": "Alice", "date_from": "2025-02-01"},
+            )
+            data = json.loads(_extract_text(result))
+            for m in data["meetings"]:
+                assert m["date"] >= "2025-02-01"
+
+    @pytest.mark.asyncio
+    async def test_date_range_scopes_results(self, mcp_server):
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "search_by_person",
+                {
+                    "person": "Alice",
+                    "date_from": "2025-01-15",
+                    "date_to": "2025-01-20",
+                },
+            )
+            data = json.loads(_extract_text(result))
+            for m in data["meetings"]:
+                assert "2025-01-15" <= m["date"] <= "2025-01-20"
+
+
+class TestE2ESummarizeMeetings:
+    """Verify summarize_meetings tool works through the MCP layer."""
+
+    @pytest.mark.asyncio
+    async def test_summarize_with_date_range(self, mcp_server):
+        """summarize_meetings with date_from/date_to returns meetings with notes."""
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "summarize_meetings",
+                {"date_from": "2025-01-01", "date_to": "2025-02-28"},
+            )
+            data = json.loads(_extract_text(result))
+            assert data["total"] >= 1
+            for m in data["meetings"]:
+                assert "notes_plain" in m
+                assert "attendees" in m
+                assert "title" in m
+
+    @pytest.mark.asyncio
+    async def test_summarize_with_person(self, mcp_server):
+        """summarize_meetings can filter by person."""
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "summarize_meetings",
+                {
+                    "date_from": "2025-01-01",
+                    "date_to": "2025-12-31",
+                    "person": "Carol",
+                },
+            )
+            data = json.loads(_extract_text(result))
+            assert data["total"] >= 1
+
+    @pytest.mark.asyncio
+    async def test_summarize_default_without_params(self, mcp_server):
+        """summarize_meetings with no params defaults to last 7 days (no error)."""
+        async with Client(mcp_server) as client:
+            result = await client.call_tool("summarize_meetings", {})
+            data = json.loads(_extract_text(result))
+            assert "total" in data
+            assert "date_from" in data
+            assert "date_to" in data
+
+
+class TestE2EExtractActionItems:
+    """Verify extract_action_items tool works through the MCP layer."""
+
+    @pytest.mark.asyncio
+    async def test_action_items_single_meeting(self, mcp_server):
+        """extract_action_items returns items from a single meeting."""
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "extract_action_items",
+                {"meeting_id": "doc-001"},
+            )
+            data = json.loads(_extract_text(result))
+            assert data["total"] >= 1
+            for item in data["action_items"]:
+                assert "action" in item
+                assert "meeting_id" in item
+                assert "meeting_title" in item
+
+    @pytest.mark.asyncio
+    async def test_action_items_date_range(self, mcp_server):
+        """extract_action_items returns items across a date range."""
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "extract_action_items",
+                {"date_from": "2025-01-01", "date_to": "2025-02-28"},
+            )
+            data = json.loads(_extract_text(result))
+            assert data["total"] >= 1
+
+    @pytest.mark.asyncio
+    async def test_action_items_nonexistent_meeting(self, mcp_server):
+        """extract_action_items with invalid meeting_id returns empty."""
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "extract_action_items",
+                {"meeting_id": "nonexistent"},
+            )
+            data = json.loads(_extract_text(result))
+            assert data["total"] == 0
+            assert data["action_items"] == []


### PR DESCRIPTION
## Summary

- **Bug fix**: `search_by_person` now supports `date_from`/`date_to` filtering — previously returned meetings from all time periods, causing year-old results to leak into recent queries
- **New tool**: `summarize_meetings` — returns meetings with notes + attendees for a time period
- **New tool**: `extract_action_items` — parses action items from Granola AI panels and bullet-point notes
- Both new tools accept `date_from`/`date_to` (YYYY-MM-DD) for explicit ranges and `days` (int) as a shortcut for "last N days"
- Updated SKILL.md with tool guidance, date parameter docs, and new workflows

## Test plan

- [x] 156 tests pass (`uv run pytest`)
- [x] Lint clean (`uv run ruff check .`)
- [x] Format clean (`uv run ruff format --check .`)
- [x] Type check clean (`uv run ty check src/`)
- [x] Manual test: call `summarize_meetings` with `days=7` and verify only recent meetings returned
- [ ] Manual test: call `extract_action_items` with a known `meeting_id` and verify panel items extracted
- [x] Manual test: call `search_by_person` with `date_from` and verify old meetings excluded