### PR TITLE
Anchor project-only patterns in .mcpbignore

### DIFF
--- a/.mcpbignore
+++ b/.mcpbignore
@@ -1,36 +1,44 @@
+# mcpb pack loads this file and treats each pattern as gitignore-style.
+# Gitignore rule that bites: a pattern without a leading `/` matches
+# anywhere in the tree, including inside `deps/` / `node_modules/`.
+# Unanchored `tests/` or `conftest.py` strips vendored runtime modules
+# and breaks imports at bundle startup. Project-only patterns are
+# anchored with `/` below; cross-tree hygiene (`__pycache__`, `*.pyc`,
+# `.DS_Store`) is left unanchored intentionally.
+
 # Development environment (deps/ is created by build action)
-.venv/
-.git/
-.github/
-.pytest_cache/
+/.venv/
+/.git/
+/.github/
+/.pytest_cache/
 __pycache__/
 *.pyc
 
 # Test files
-tests/
+/tests/
 
 # Build artifacts
-dist/
-build/
+/dist/
+/build/
 *.egg-info/
 
 # Dev config
-Makefile
-.tasks/
-CACHE_V6_MIGRATION.md
-scripts/
-pytest.ini
-.env
-.env.*
+/Makefile
+/.tasks/
+/CACHE_V6_MIGRATION.md
+/scripts/
+/pytest.ini
+/.env
+/.env.*
 
 # Lock files
-uv.lock
+/uv.lock
 
 # IDE
-.vscode/
-.idea/
-.claude/
+/.vscode/
+/.idea/
+/.claude/
 
 # Mypy/ruff cache
-.mypy_cache/
-.ruff_cache/
+/.mypy_cache/
+/.ruff_cache/


### PR DESCRIPTION
## Summary

Unanchored gitignore patterns in `.mcpbignore` match anywhere in the tree, including inside vendored `deps/` or `node_modules/`. `mcpb pack` then strips legitimate runtime files from bundled packages.

The trap fired on [synapse-research 0.1.1](https://github.com/NimbleBrainInc/synapse-research/releases/tag/v0.1.2) and [openweathermap 0.4.0](https://github.com/NimbleBrainInc/mcp-openweathermap/releases/tag/v0.4.1) — an unanchored `conftest.py` pattern stripped `deps/beartype/_conf/conftest.py` (a real runtime module), breaking the FastMCP import chain and crashing the MCP subprocess with `MCP error -32000: Connection closed`.

This PR anchors project-only patterns with a leading `/`, leaves cross-tree hygiene (`__pycache__/`, `*.pyc`, `.DS_Store`) unanchored, and drops the redundant `conftest.py` rule (already covered by `/tests/`).

No behavior change for the currently-published artifact — this is preventive. The next release from this repo will produce a bundle that keeps vendored deps intact.

Matches the canonical `.mcpbignore` shape in [`mcp-server-template-python`](https://github.com/NimbleBrainInc/mcp-server-template-python/pull/12) and [`mcp-server-template-typescript`](https://github.com/NimbleBrainInc/mcp-server-template-typescript/pull/3).

## Test plan

- [ ] `make bundle` (or equivalent) and confirm no regressions in the packaged output
- [ ] On next release, verify the published bundle still starts cleanly